### PR TITLE
`with-redef-calls` shouldn't always return `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
-## [0.1.1] - 2018-01-23
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
 ### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2018-01-23
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
+- `with-redef-calls` will return its body's value.
 
 [Unreleased]: https://github.com/your-name/dwarf/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/your-name/dwarf/compare/0.1.0...0.1.1

--- a/src/dwarf/mock.cljc
+++ b/src/dwarf/mock.cljc
@@ -23,13 +23,15 @@
 (defn- with-redef-call-f
   [[original-fn new-fn] & code]
   `(let [called?# (atom false)
+         return-value# (atom nil)
          wrapped-new-fn# (fn [& args#]
                            (reset! called?# true)
                            (apply ~new-fn args#))]
      (with-redefs [~original-fn wrapped-new-fn#]
-       ~@code)
+       (reset! return-value# ~@code))
      (when-not @called?#
-       (redef-error ~original-fn))))
+       (redef-error ~original-fn))
+     @return-value#))
 
 (defn- correct-code-parameter
   "Fixes up the seq which is the code to put in a macro.

--- a/test/dwarf/mock_test.cljc
+++ b/test/dwarf/mock_test.cljc
@@ -11,12 +11,11 @@
 
 (deftest test-with-redef-calls
   (testing "Redefined function is called, error is never raised."
-    (with-redefs
-     [dwarf.mock/redef-error
-      (fn [f]
-        (do-report {:type :fail
-                    :expected "dwarf.test/redef-error to never be called."
-                    :actual "dwarf.test/redef-error was called."}))]
+    (with-redefs [dwarf.mock/redef-error
+                  (fn [f]
+                    (do-report {:type :fail
+                                :expected "dwarf.test/redef-error to never be called."
+                                :actual "dwarf.test/redef-error was called."}))]
       (with-redef-calls [test-fn (fn [s]
                                    (is (= s "test")))]
         (test-fn "test"))))
@@ -24,4 +23,8 @@
     (with-redefs [dwarf.mock/redef-error
                   (fn [f]
                     (is (= (f nil) :fn)))]
-      (with-redef-calls [test-fn (fn [_])]))))
+      (with-redef-calls [test-fn (fn [_])])))
+  (testing "with-redef-calls is returning"
+    (is (= :x
+           (with-redef-calls [test-fn (fn [arg] arg)]
+             (test-fn :x))))))


### PR DESCRIPTION
Unlike `with-redefs`, `with-redef-calls` wasn't returning its body's value. This was discovered when we tried to use it inside `are` call, which made some of our tests silently fail.

This PR makes sure `with-redef-calls` behaves like `with-redefs` does.